### PR TITLE
feature(android): add support for badge count

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,10 +12,15 @@ android {
     }
 }
 
+repositories {
+    mavenCentral()
+}
+
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.facebook.react:react-native:+'
     compile 'com.google.firebase:firebase-core:9.+'
     compile 'com.google.firebase:firebase-messaging:9.+'
+    compile 'me.leolin:ShortcutBadger:1.1.10@aar'
 }
 

--- a/android/src/main/java/com/evollu/react/fcm/MessagingService.java
+++ b/android/src/main/java/com/evollu/react/fcm/MessagingService.java
@@ -1,7 +1,9 @@
 package com.evollu.react.fcm;
 
+import java.util.Map;
 import android.content.Intent;
 import android.util.Log;
+import me.leolin.shortcutbadger.ShortcutBadger;
 
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
@@ -16,6 +18,19 @@ public class MessagingService extends FirebaseMessagingService {
         Log.d(TAG, "Remote message received");
         Intent i = new Intent("com.evollu.react.fcm.ReceiveNotification");
         i.putExtra("data", remoteMessage);
+        if(remoteMessage.getData() != null){
+            Map data = remoteMessage.getData();
+            if (data.get("badge") != null) {
+                int badgeCount = Integer.parseInt((String)data.get("badge"));
+                if (badgeCount == 0) {
+                    Log.d(TAG, "Remove count");
+                    ShortcutBadger.removeCount(this);
+                } else {
+                    Log.d(TAG, "Apply count: " + badgeCount);
+                    ShortcutBadger.applyCount(this, badgeCount);
+                }
+            }
+        }
         sendOrderedBroadcast(i, null);
     }
 }

--- a/android/src/main/java/com/evollu/react/fcm/MessagingService.java
+++ b/android/src/main/java/com/evollu/react/fcm/MessagingService.java
@@ -21,13 +21,17 @@ public class MessagingService extends FirebaseMessagingService {
         if(remoteMessage.getData() != null){
             Map data = remoteMessage.getData();
             if (data.get("badge") != null) {
-                int badgeCount = Integer.parseInt((String)data.get("badge"));
-                if (badgeCount == 0) {
-                    Log.d(TAG, "Remove count");
-                    ShortcutBadger.removeCount(this);
-                } else {
-                    Log.d(TAG, "Apply count: " + badgeCount);
-                    ShortcutBadger.applyCount(this, badgeCount);
+                try {
+                    int badgeCount = Integer.parseInt((String)data.get("badge"));
+                    if (badgeCount == 0) {
+                        Log.d(TAG, "Remove count");
+                        ShortcutBadger.removeCount(this);
+                    } else {
+                        Log.d(TAG, "Apply count: " + badgeCount);
+                        ShortcutBadger.applyCount(this, badgeCount);
+                    }
+                } catch (Exception e) {
+                    Log.e(TAG, "Badge count needs to be an integer", e);
                 }
             }
         }


### PR DESCRIPTION
Android does not natively support badge counters, so we utilize shortcut badger to be able to show badge counters.
To trigger these updates one needs to send a "badge" parameter in the "data" payload of a push notification. If the app is dead (as opposed to just in the background, one cannot send the "notification" payload in the push notification as the OS then takes over control.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/edtechfoundry/react-native-fcm/1)

<!-- Reviewable:end -->
